### PR TITLE
Create doc directory before installing into it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ clean:
 install: $(APP)
 	mkdir -p "$(DESTDIR)$(PREFIX)/bin"
 	install -m 755 avcut "$(DESTDIR)$(PREFIX)/bin/"
+	mkdir -p "$(DESTDIR)$(PREFIX)/share/doc/$(APP)/"
 	install -m 644 README.md "$(DESTDIR)$(PREFIX)/share/doc/$(APP)/"
 	
 	mkdir -p $(DESTDIR)$(AVCUT_PROFILE_DIRECTORY)


### PR DESCRIPTION
In addition to the previous changes to the Makefile we need to ensure that the documentation directory exists before installing into it.