### PR TITLE
Provide a dockerfile to compile the source

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM gentoo/stage3-amd64
+MAINTAINER https://github.com/laeubi
+
+RUN mkdir -p /usr/portage && \
+	emerge-webrsync && \
+	emerge media-video/ffmpeg && \
+	rm -rf /usr/portage
+WORKDIR /build
+CMD make

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,18 @@
+avcut - docker build container
+==============================
+
+
+this container allows to build avcut
+without install dependencies on the host
+
+Build the container
+-------------------
+
+Build `docker build -t avcut .`
+
+Compile
+-------------------
+Change to an empty directory (e.g. /home/your_user/avcut
+Checkout `git clone https://github.com/anyc/avcut.git .`
+Compile `docker run --rm -v /home/your_user/avcut/:/build avcut`
+Binary is placed inside your directory if command finished


### PR DESCRIPTION
This dockerfile allows to build avcut without having all deps on the host system.