### PR TITLE
Add a parameter to output progress information

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,17 @@ Usage: avcut [options] [<drop_from_ts> <continue_with_ts> ...]
 
 Options:
 
-  -c            Create a shell script to check cutpoints with mpv
-  -d <diff>     Accept this difference in packet sizes during packet matching
-  -i <file>     Input file
-  -o <file>     Output file
-  -p <profile>  Use this encoding profile. If <profile> ends with ".profile",
-                <profile> is used as a path to the profile file. If not, the profile
-                is loaded from the default profile directory:
-                   /usr/share/avcut/profiles/
-  -s <index>    Skip stream with this index
-  -v <level>    Set verbosity level (see https://www.ffmpeg.org/doxygen/2.8/log_8h.html)
+  -c              Create a shell script to check cutpoints with mpv
+  -d <diff>       Accept this difference in packet sizes during packet matching
+  -i <file>       Input file
+  -o <file>       Output file
+  -p <profile>    Use this encoding profile. If <profile> ends with ".profile",
+                  <profile> is used as a path to the profile file. If not, the profile
+                  is loaded from the default profile directory:
+                     /usr/share/avcut/profiles/
+  -s <index>      Skip stream with this index
+  -v <level>      Set verbosity level (see https://www.ffmpeg.org/doxygen/2.8/log_8h.html)
+  -f <framecount> provide the approximate total frame count to show progress information
 ```
 
 Besides the input and output file, avcut expects a "blacklist", i.e. what should

--- a/avcut.c
+++ b/avcut.c
@@ -287,7 +287,7 @@ char find_packet_for_frame(struct project *pr, struct packet_buffer *s, size_t f
 			// libav is missing pkt_size
 			if (s->frames[frame_idx]->pkt_size != s->pkts[i].size - pr->size_diff) {
 				av_log(NULL, AV_LOG_ERROR,
-						"size mismatch %zu:%d %zu:%d (diff: %lu, try: )\n",
+						"size mismatch %zu:%d %zu:%d (diff: %lu, try: %d)\n",
 						frame_idx, s->frames[frame_idx]->pkt_size, i,
 						s->pkts[i].size, pr->size_diff,
 						s->pkts[i].size - s->frames[frame_idx]->pkt_size);
@@ -794,16 +794,17 @@ void help() {
 	av_log(NULL, AV_LOG_INFO, "\n");
 	av_log(NULL, AV_LOG_INFO, "Options:\n");
 	av_log(NULL, AV_LOG_INFO, "\n");
-	av_log(NULL, AV_LOG_INFO, "  -c            Create a shell script to check the cutpoints with mpv\n");
-	av_log(NULL, AV_LOG_INFO, "  -d <diff>     Accept this difference in packet sizes during packet matching\n");
-	av_log(NULL, AV_LOG_INFO, "  -i <file>     Input file\n");
-	av_log(NULL, AV_LOG_INFO, "  -o <file>     Output file\n");
-	av_log(NULL, AV_LOG_INFO, "  -p <profile>  Use this encoding profile. If <profile> ends with \".profile\",\n");
-	av_log(NULL, AV_LOG_INFO, "                <profile> is used as a path to the profile file. If not, the profile\n");
-	av_log(NULL, AV_LOG_INFO, "                is loaded from the default profile directory:\n");
-	av_log(NULL, AV_LOG_INFO, "                   %s\n", AVCUT_PROFILE_DIRECTORY);
-	av_log(NULL, AV_LOG_INFO, "  -s <index>    Skip stream with this index\n");
-	av_log(NULL, AV_LOG_INFO, "  -v <level>    Set verbosity level (see https://www.ffmpeg.org/doxygen/2.8/log_8h.html)\n");
+	av_log(NULL, AV_LOG_INFO, "  -c              Create a shell script to check the cutpoints with mpv\n");
+	av_log(NULL, AV_LOG_INFO, "  -d <diff>       Accept this difference in packet sizes during packet matching\n");
+	av_log(NULL, AV_LOG_INFO, "  -i <file>       Input file\n");
+	av_log(NULL, AV_LOG_INFO, "  -o <file>       Output file\n");
+	av_log(NULL, AV_LOG_INFO, "  -p <profile>    Use this encoding profile. If <profile> ends with \".profile\",\n");
+	av_log(NULL, AV_LOG_INFO, "                  <profile> is used as a path to the profile file. If not, the profile\n");
+	av_log(NULL, AV_LOG_INFO, "                  is loaded from the default profile directory:\n");
+	av_log(NULL, AV_LOG_INFO, "                    %s\n", AVCUT_PROFILE_DIRECTORY);
+	av_log(NULL, AV_LOG_INFO, "  -s <index>      Skip stream with this index\n");
+	av_log(NULL, AV_LOG_INFO, "  -v <level>      Set verbosity level (see https://www.ffmpeg.org/doxygen/2.8/log_8h.html)\n");
+	av_log(NULL, AV_LOG_INFO, "  -f <framecount> provide the approximate total frame count to show progress information\n");
 	av_log(NULL, AV_LOG_INFO, "\n");
 	av_log(NULL, AV_LOG_INFO, "Besides the input and output file, avcut expects a \"blacklist\", i.e. what should\n");
 	av_log(NULL, AV_LOG_INFO, "be dropped, as argument. This blacklist consists of timestamps that denote from\n");
@@ -818,7 +819,7 @@ void help() {
 }
 
 int main(int argc, char **argv) {
-	unsigned int i, j, n_skip_streams;
+	unsigned int i, j, n_skip_streams,max_framecount;
 	unsigned int *skip_streams;
 	unsigned long size_diff;
 	int ret, opt, create_check_script;
@@ -834,7 +835,8 @@ int main(int argc, char **argv) {
 	outputf = 0;
 	profile = 0;
 	size_diff = 0;
-	while ((opt = getopt (argc, argv, "hi:o:p:v:cd:s:")) != -1) {
+	max_framecount=0;
+	while ((opt = getopt (argc, argv, "hi:o:p:v:cd:s:f:")) != -1) {
 		switch (opt) {
 			case 'h':
 				help();
@@ -853,6 +855,18 @@ int main(int argc, char **argv) {
 				break;
 			case 'c':
 				create_check_script = 1;
+				break;
+			case 'f':
+				{
+					char *end;
+
+					max_framecount = strtol(optarg, &end, 10);
+					if (end == optarg || *end != 0) {
+						av_log(NULL, AV_LOG_ERROR, "error while parsing size_diff: %s\n", optarg);
+						help();
+						return 1;
+					}
+				}
 				break;
 			case 'd':
 				{
@@ -1242,7 +1256,7 @@ int main(int argc, char **argv) {
 		sbuffer[j].next_dts = dts_offset;
 		av_log(NULL, AV_LOG_DEBUG, "initial DTS %u: %.0f\n", j, sbuffer[j].next_dts);
 	}
-	
+	int current_percent = -1;
 	// start processing the input
 	pr->stop_reading = 0;
 	while (!pr->stop_reading) {
@@ -1255,11 +1269,19 @@ int main(int argc, char **argv) {
 			break;
 		}
 		
-		if (pr->in_fctx->streams[packet.stream_index]->codec->codec_type == AVMEDIA_TYPE_VIDEO)
+		if (pr->in_fctx->streams[packet.stream_index]->codec->codec_type == AVMEDIA_TYPE_VIDEO) {
 			pr->video_packets_read++;
-		else
+			if (max_framecount > 0) {
+				int percent = ((pr->video_packets_read) * 100) / max_framecount;
+				if (percent > current_percent) {
+					fprintf( stdout, "processed %03d\r\n", percent);
+					fflush( stdout );
+					current_percent = percent;
+				}
+			}
+		} else {
 			pr->other_packets_read++;
-		
+		}
 		// calculate output stream_index from packet's input stream_index
 		for (i=0; i<pr->n_stream_ids; i++) {
 			if (pr->stream_ids[i] == packet.stream_index) {


### PR DESCRIPTION
This prints some progress information if you supply the count of frames with then -f parameter (e.g. fetched from a cutlist with lastcut cutstartFrame+cutDurationframes)